### PR TITLE
lighthouse 사용자 접근성 개선

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -37,29 +37,26 @@ const StyledHeading = styled.h1`
 const Header = () => {
   return (
     <StyledHeader>
-        <StyledHeading>
-          <Link to="/">형주의 블로그</Link>
-        </StyledHeading>
+      <StyledHeading>
+        <Link to="/">형주의 블로그</Link>
+      </StyledHeading>
       <RightSection>
         <StyledHeading>
-          <Link to="/projects">
-            Projects
-          </Link>
+          <Link to="/projects">Projects</Link>
         </StyledHeading>
         <StyledHeading>
           <ThemeSwitchToggle />
         </StyledHeading>
         <StyledHeading>
-          <Link target="_blank" to="https://github.com/nokiahub">
+          <Link target="_blank" to="https://github.com/nokiahub" aria-label="my github account">
             <GithubIcon />
           </Link>
         </StyledHeading>
         <StyledHeading>
-          <Link to="/about">
+          <Link to="/about" aria-label="about me">
             <Information size={24} />
           </Link>
         </StyledHeading>
-
       </RightSection>
     </StyledHeader>
   );

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -50,7 +50,7 @@ const Layout = ({ location, children }: PageProps) => {
         <Header />
         <main>{children}</main>
         <Footer />
-        <ScrollToTop onClick={handleClickScrollToTop}>
+        <ScrollToTop onClick={handleClickScrollToTop} aria-label="scroll to top">
           <ArrowUp size={20} />
         </ScrollToTop>
       </Wrapper>

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -25,15 +25,15 @@ const Pagination = ({ totalPages, currentPage }: Props) => {
   return (
     <StyledList>
       {items.map((_, index) => (
-        <StyledLink
-          fontWeight={
-            index + 1 === currentPage ? typography.fontWeightBold : typography.fontWeightNormal
-          }
-          key={index}
-          to={index === 0 ? '/' : `/${index + 1}`}
-        >
-          {index + 1}
-        </StyledLink>
+        <li key={index}>
+          <StyledLink
+            fontWeight={
+              index + 1 === currentPage ? typography.fontWeightBold : typography.fontWeightNormal
+            }
+            to={index === 0 ? '/' : `/${index + 1}`}>
+            {index + 1}
+          </StyledLink>
+        </li>
       ))}
     </StyledList>
   );


### PR DESCRIPTION
- 맨 위로 스크롤 버튼에 `aria-label` 추가
- 깃헙, about 링크에 `aria-label` 추가
- 페이지네이션 번호를 `<li>` 태그로 래핑
